### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lagoni/edavisualiser",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lagoni/edavisualiser",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^1.15.0",

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/edavisualiser",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": false,
   "description": "A React flow library for visualizing event driven architectures.",
   "repository": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.13.0](https://github.com/jonaslagoni/EDAVisualiser/releases/tag/v0.13.0)