### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/edavisualiser",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/edavisualiser",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "private": false,
   "description": "A React flow library for visualizing event driven architectures.",
   "repository": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.17.0](https://github.com/jonaslagoni/EDAVisualiser/releases/tag/v0.17.0)